### PR TITLE
FIX Don't pass input that doesn't exist to workflow

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -89,7 +89,7 @@ jobs:
             -H "Authorization: Bearer ${{ github.token }}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/tag-patch-release.yml/dispatches \
-            -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"${{ needs.ci.outputs.latest_local_sha }}\",\"dispatch_gha_autotag\":${{ needs.ci.outputs.has_auto_tag }}}}"
+            -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"${{ needs.ci.outputs.latest_local_sha }}\"}}"
           )
           if [[ $RESP_CODE != "204" ]]; then
             echo "Failed to dispatch workflow - HTTP response code was $RESP_CODE"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/gha-action-ci/actions/runs/10276649842/job/28437579552
> Unexpected inputs provided: [\"dispatch_gha_autotag\"]

That's an input for https://github.com/silverstripe/gha-tag-release but not for the workflow file in each individual repo.
Instead of adding that input to the individual repo workflow files, I'll update those files only in gha-* repos to pass in a hardcoded value of true to that input (see https://github.com/silverstripe/module-standardiser/pull/69)

## Issue
- https://github.com/silverstripe/gha-action-ci/issues/13